### PR TITLE
Include all price columns

### DIFF
--- a/src/coinbase.py
+++ b/src/coinbase.py
@@ -19,7 +19,7 @@ class CoinbaseAPI():
     - get_wallet_balance(self)
         Retrieves the account balance of the user's wallet on Coinbase.
     - get_live_data(self)
-        Retrieves the real-time price of a specified cryptocurrency on Coinbase.
+        Retrieves the real-time price data of a specified cryptocurrency on Coinbase.
     - get_historical_data(self)
         Retrieves the historical price data of a specified cryptocurrency on Coinbase.
     """
@@ -75,7 +75,7 @@ class CoinbaseAPI():
             'open': [float(data['open'])],
             'close': [float(data['last_trade_price'])]
         })
-        
+
         return price_data
     
     # Get historical price data

--- a/src/coinbase.py
+++ b/src/coinbase.py
@@ -60,15 +60,22 @@ class CoinbaseAPI():
     # Get live price data
     def get_live_data(self):
         endpoint = f'{self.base_url}/prices/{self.product_id}-USD/spot'
-        params = {'currency': {self.product_id}}
 
-        response = requests.get(endpoint, params=params)
+        response = requests.get(endpoint)
         data = response.json()['data']
 
         timestamp = pd.to_datetime(data['timestamp']).tz_localize(None)
 
-        price = float(data['amount'])
-        price_data = pd.DataFrame({'timestamp': [timestamp], 'price': [price]})
+        price_data = pd.DataFrame({
+            'timestamp': [timestamp],
+            'price': [float(data['price'])],
+            'volume': [float(data['volume'])],
+            'low': [float(data['low'])],
+            'high': [float(data['high'])],
+            'open': [float(data['open'])],
+            'close': [float(data['last_trade_price'])]
+        })
+        
         return price_data
     
     # Get historical price data
@@ -90,6 +97,5 @@ class CoinbaseAPI():
         
         df['time'] = pd.to_datetime(df['time'], unit='s')
         df = df.set_index('time')
-        df = df[['open']]
         
         return df

--- a/src/cryptotrader.py
+++ b/src/cryptotrader.py
@@ -274,7 +274,7 @@ class CryptoTrader:
             self.concat_indicators(data)  # Add indicators to the data
             self.update_model(data)  # Update the model
             predicted_price, confidence = self.predict()  # Predicted price
-            current_price = data['price'][0]  # Current price
+            current_price = data['close'][0]  # Current price
             order, balance = self.get_order_amount()  # Order amount
             trade_decision = self.make_trade_decision(predicted_price=predicted_price,  # Make a trade decision
                                                        current_price=current_price,

--- a/src/cryptotrader.py
+++ b/src/cryptotrader.py
@@ -88,9 +88,9 @@ class CryptoTrader:
 
     # Define and initialize the model, optimizer, and loss function
     def initialize_model(self):
-        indicator_size = len(self.price_data.columns) - 2 # Number of indicator columns
+        input_size = len(self.price_data) - 1   # Number of input columns
 
-        self.model = CryptoModel(model_class=self.model_class, input_size=1, indicator_size=indicator_size, hidden_size=128, output_size=1, verbose=self.verbose) # Model instance
+        self.model = CryptoModel(model_class=self.model_class, input_size=input_size, hidden_size=128, output_size=1, verbose=self.verbose) # Model instance
 
     # Get live data
     def get_live_data(self):
@@ -110,9 +110,9 @@ class CryptoTrader:
     # Add indicators to the data
     def concat_indicators(self, data):
         # Compute the indicators
-        data['sma'] = ta.sma(data['price'], length=20)                            # Simple Moving Average
-        data['rsi'] = ta.rsi(data['price'], length=14)                            # Relative Strength Index
-        data['macd'], _, _ = ta.macd(data['price'], fast=12, slow=26, signal=9)   # Moving Average  Convergence Divergence
+        data['sma'] = ta.sma(data['close'], length=20)                            # Simple Moving Average
+        data['rsi'] = ta.rsi(data['close'], length=14)                            # Relative Strength Index
+        data['macd'], _, _ = ta.macd(data['close'], fast=12, slow=26, signal=9)   # Moving Average  Convergence Divergence
 
         data.dropna(inplace=True)  # Drop rows with NaN values
         data.reset_index(drop=True, inplace=True)  # Reset the index
@@ -225,7 +225,7 @@ class CryptoTrader:
             self.concat_indicators(live_data)              # Add indicators to the data
             self.update_model(self.price_data)                          # Update the model
             predicted_price, confidence = self.predict(self.price_data) # Predicted price
-            current_price = live_data['price'][0]                       # Current price
+            current_price = live_data['close'][0]                       # Current price
             order, balance = self.get_order_amount()                    # Order amount
             trade_decision = self.make_trade_decision(predicted_price=predicted_price,  # Make a trade decision
                                                       current_price=current_price, 

--- a/src/models/crypto_lstm.py
+++ b/src/models/crypto_lstm.py
@@ -43,7 +43,6 @@ class CryptoLSTM(nn.Module):
         self.verbose = verbose  # Verbose debug flag
 
     # Define the forward function
-    #TODO: What is indicator here?
     def forward(self, x, hidden):
         out, hidden = self.lstm(x, hidden)                  # Pass input and previous hidden state through LSTM layer
         out = self.fc1(out[:, -1, :])                       # Pass output of LSTM layer through first fully connected layer
@@ -62,10 +61,6 @@ class CryptoLSTM(nn.Module):
         #TODO: What even is seq_length?
         sequences = []
         targets = []
-
-        # Extract price and indicator data
-        price_data = data[['price']]
-        indicator_data = data.drop(columns=['price'])
 
         # Iterate over the data to create sequences
         for i in range(seq_length, len(data)):

--- a/src/models/crypto_lstm.py
+++ b/src/models/crypto_lstm.py
@@ -26,13 +26,13 @@ class CryptoLSTM(nn.Module):
 
     """
     #TODO: Is this model set up correctly?
-    def __init__(self, input_size, indicator_size, hidden_size, output_size, verbose=False):
+    def __init__(self, input_size, hidden_size, output_size=1, verbose=False):
         super(CryptoLSTM, self).__init__()
         # Define the layers
         self.hidden_size = hidden_size
         self.lstm = nn.LSTM(input_size, hidden_size, batch_first=True)      # LSTM layer
         self.fc1 = nn.Linear(hidden_size, hidden_size//2)                   # Fully-connected layer 1
-        self.fc2 = nn.Linear(hidden_size//2 + indicator_size, output_size)  # Fully-connected layer 2
+        self.fc2 = nn.Linear(hidden_size//2 + input_size, output_size)      # Fully-connected layer 2
         self.sigmoid = nn.Sigmoid()                                         # Sigmoid activation function
 
         # Define model parameters
@@ -43,6 +43,7 @@ class CryptoLSTM(nn.Module):
         self.verbose = verbose  # Verbose debug flag
 
     # Define the forward function
+    #TODO: What is indicator here?
     def forward(self, x, hidden, indicator):
         out, hidden = self.lstm(x, hidden)                  # Pass input and previous hidden state through LSTM layer
         out = self.fc1(out[:, -1, :])                       # Pass output of LSTM layer through first fully connected layer

--- a/src/models/crypto_lstm.py
+++ b/src/models/crypto_lstm.py
@@ -44,11 +44,11 @@ class CryptoLSTM(nn.Module):
 
     # Define the forward function
     #TODO: What is indicator here?
-    def forward(self, x, hidden, indicator):
+    def forward(self, x, hidden):
         out, hidden = self.lstm(x, hidden)                  # Pass input and previous hidden state through LSTM layer
         out = self.fc1(out[:, -1, :])                       # Pass output of LSTM layer through first fully connected layer
         out = self.sigmoid(out)                             # Apply sigmoid activation function
-        out = self.fc2(torch.cat((out, indicator), dim=1))  # Concatenate output of first fully connected layer with indicator data and pass through second fully connected layer
+        out = self.fc2(out)                                 # Pass output of first fully connected layer through second fully connected layer
         out = self.sigmoid(out)                             # Apply sigmoid activation function
         return out, hidden
     
@@ -69,12 +69,8 @@ class CryptoLSTM(nn.Module):
 
         # Iterate over the data to create sequences
         for i in range(seq_length, len(data)):
-            sequence = price_data[i - seq_length:i]
-            target = data[i:i+1]['price'].values[0]
-
-            # Add indicator values to the sequence
-            indicators = indicator_data[i - seq_length:i].values
-            sequence = np.hstack([sequence.values, indicators])
+            sequence = data.iloc[i - seq_length:i].values
+            target = data.iloc[i, 0]
 
             sequences.append(sequence)
             targets.append(target)

--- a/src/models/crypto_lstm.py
+++ b/src/models/crypto_lstm.py
@@ -89,8 +89,8 @@ class CryptoLSTM(nn.Module):
         # Train the model
         for epoch in range(epochs):
             running_loss = 0.0
-            for i, data in enumerate(dataloader):
-                inputs, labels = data
+            for i, data_load in enumerate(dataloader):
+                inputs, labels = data_load
                 self.optimizer.zero_grad()
                 outputs = self.model(inputs)
                 loss = self.criterion(outputs, labels)
@@ -103,8 +103,8 @@ class CryptoLSTM(nn.Module):
     def predict(self, data, hidden):
         self.eval()     # Toggle evaluation mode
         with torch.no_grad():
-            input_seq = data.iloc[-1:, 1:].values
-            input_seq = torch.tensor(input_seq).unsqueeze(1).float()
+            input_seq = data.iloc[-1:, :].values                        # Last row of dataframe (most recent features)
+            input_seq = torch.tensor(input_seq).unsqueeze(1).float()    #TODO: do we want to predict with a sequence > 1?
             output, _ = self(input_seq, hidden)
             predicted_price = output.item()
             confidence = 1.0 - self.criterion(output, input_seq[:, -1:, :]).item()

--- a/src/models/crypto_lstm.py
+++ b/src/models/crypto_lstm.py
@@ -30,6 +30,7 @@ class CryptoLSTM(nn.Module):
         super(CryptoLSTM, self).__init__()
         # Define the layers
         self.hidden_size = hidden_size
+        self.hidden = (torch.zeros(1, 1, self.hidden_size), torch.zeros(1, 1, self.hidden_size))  # Hidden layer
         self.lstm = nn.LSTM(input_size, hidden_size, batch_first=True)      # LSTM layer
         self.fc1 = nn.Linear(hidden_size, hidden_size//2)                   # Fully-connected layer 1
         self.fc2 = nn.Linear(hidden_size//2 + input_size, output_size)      # Fully-connected layer 2
@@ -44,7 +45,7 @@ class CryptoLSTM(nn.Module):
 
     # Define the forward function
     def forward(self, x, hidden):
-        out, hidden = self.lstm(x, hidden)                  # Pass input and previous hidden state through LSTM layer
+        out, self.hidden = self.lstm(x, hidden)                  # Pass input and previous hidden state through LSTM layer
         out = self.fc1(out[:, -1, :])                       # Pass output of LSTM layer through first fully connected layer
         out = self.sigmoid(out)                             # Apply sigmoid activation function
         out = self.fc2(out)                                 # Pass output of first fully connected layer through second fully connected layer
@@ -111,8 +112,8 @@ class CryptoLSTM(nn.Module):
         return predicted_price, confidence
     
     # Update the model with new data
-    def update_model(self, data):
-        input_seq, target_seq = self.create_sequences(data=data, seq_length=1)
+    def update_model(self, data, seq_length=1):
+        input_seq, target_seq = self.create_sequences(data=data, seq_length=seq_length)
         self.optimizer.zero_grad()  # Clear the gradients from the optimizer
 
         output, self.hidden = self(input_seq, self.hidden)  # Pass the input sequence and previous hidden state through the model

--- a/src/models/crypto_lstm.py
+++ b/src/models/crypto_lstm.py
@@ -15,8 +15,8 @@ class CryptoLSTM(nn.Module):
 
     ### Methods:
     -----------
-    - __init__(self, input_size, indicator_size, hidden_size, output_size)
-        Initializes the LSTM model with the specified input, indicator, and output sizes.
+    - __init__(self, input_size, hidden_size, output_size)
+        Initializes the LSTM model with the specified input, and output sizes.
     - create_sequences(self, data, seq_length=10)
         Converts the historical price data to sequences and labels for training.
     - train(self, data, batch_size=32, epochs=10)

--- a/test/cryptotrader_test.py
+++ b/test/cryptotrader_test.py
@@ -1,17 +1,14 @@
 ## Crypto Trading Algorithm - Test File
 # Harrison Floam, 10 April 2023
 
+
 # Import Libraries
 import unittest
 from unittest.mock import Mock
 
-# Import Modules
+# Import Modules and Packages
 import src
 
-
-#TODO: Create class that makes test data, with patterns that look like BTC. Pull old BTC data?
-#TODO: Create CryptoTrader instances in test mode
-#TODO: Need a way to compare results to actual... is it overfitting?
 
 class TestCryptoTrader(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
Modified methods in crypto_lstm.py and cryptotrader.py. Closes #7 for now.

Concerns:
- Too small a trading interval might not have all price columns available
- Model might take too long to train/query with more columns
- Extra columns might just add noise